### PR TITLE
Use java.util.Base64 instead of apache Base64

### DIFF
--- a/src/main/java/me/bradleysteele/commons/itemstack/SkullBuilder.java
+++ b/src/main/java/me/bradleysteele/commons/itemstack/SkullBuilder.java
@@ -20,11 +20,11 @@ import me.bradleysteele.commons.nms.wrapped.profile.NMSGameProfile;
 import me.bradleysteele.commons.nms.wrapped.profile.NMSProperty;
 import me.bradleysteele.commons.util.Players;
 import me.bradleysteele.commons.util.reflect.Reflection;
-import org.apache.commons.codec.binary.Base64;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -69,7 +69,7 @@ public class SkullBuilder extends ItemStackBuilder {
 
         if (url != null) {
             NMSGameProfile profile = new NMSGameProfile(UUID.randomUUID(), null);
-            profile.getProperties().put("textures", new NMSProperty("textures", new String(Base64.encodeBase64(String.format(TEXTURES_JSON, url).getBytes()))));
+            profile.getProperties().put("textures", new NMSProperty("textures", Base64.getMimeEncoder().encodeToString(String.format(TEXTURES_JSON, url).getBytes())));
 
             // Apply to meta
             Reflection.setFieldValue("profile", meta, profile.getNMSHandle());

--- a/src/main/java/me/bradleysteele/commons/util/OfflinePlayers.java
+++ b/src/main/java/me/bradleysteele/commons/util/OfflinePlayers.java
@@ -24,7 +24,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -32,6 +31,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -88,7 +88,7 @@ public final class OfflinePlayers {
                     JsonObject properties = array.get(array.size() - 1).getAsJsonObject();
 
                     // texture
-                    JsonObject value = parser.parse(new String(Base64.decodeBase64(properties.get("value").toString().getBytes()))).getAsJsonObject();
+                    JsonObject value = parser.parse(new String(Base64.getMimeDecoder().decode(properties.get("value").toString()))).getAsJsonObject();
                     JsonObject textures = value.get("textures").getAsJsonObject();
                     JsonObject skin = textures.get("SKIN").getAsJsonObject();
 


### PR DESCRIPTION
This means BCommons doesn't need to depend directly on apache commons-codec. (httpclient still does, but that's okay)